### PR TITLE
Use `XkbIndicatorNotifyEvent` instead of a timer.

### DIFF
--- a/panel-plugin/kbdleds.c
+++ b/panel-plugin/kbdleds.c
@@ -29,6 +29,7 @@
 #include <gtk/gtk.h>
 #include <libxfce4util/libxfce4util.h>
 #include <libxfce4panel/libxfce4panel.h>
+#include <X11/XKBlib.h>
 
 #include "kbdleds.h"
 #include "kbdleds-dialogs.h"
@@ -42,8 +43,6 @@ kbdleds_construct (XfcePanelPlugin *plugin);
 
 /* register the plugin */
 XFCE_PANEL_PLUGIN_REGISTER (kbdleds_construct);
-
-guint timeoutId;
 
 void show_error(gchar *message) {
   GtkDialogFlags flags = GTK_DIALOG_DESTROY_WITH_PARENT;
@@ -186,13 +185,12 @@ kbdleds_free (XfcePanelPlugin *plugin,
   //if (G_LIKELY (kbdleds->setting1 != NULL))
     //g_free (kbdleds->setting1);
 
+  /* remove the callbacks */
+  xkbleds_finish();
+
   /* free the plugin structure */
   g_slice_free (kbdledsPlugin, kbdleds);
 
-  /* free the timeout */
-  if (timeoutId) {
-    g_source_remove(timeoutId);
-  }
 }
 
 static void
@@ -272,22 +270,6 @@ void refresh() {
   g_free(label_str);
 }
 
-gboolean kbdleds_update_state(gpointer data) {
-
-  if (!xkbleds_get_state()) {
-    // stop g_timeout
-    return FALSE;
-  }
-//    syslog(LOG_DEBUG,"%d",kbd_state);
-
-  if (xkb_state != old_xkb_state) {
-
-    refresh();
-
-  }
-  return TRUE;
-}
-
 static void
 kbdleds_construct (XfcePanelPlugin *plugin)
 {
@@ -328,6 +310,4 @@ kbdleds_construct (XfcePanelPlugin *plugin)
                     G_CALLBACK (kbdleds_about), NULL);
 
   xkbleds_init();
-  timeoutId = g_timeout_add(250, kbdleds_update_state, NULL);
-
 }

--- a/panel-plugin/xkbleds.h
+++ b/panel-plugin/xkbleds.h
@@ -30,7 +30,8 @@ extern char short_lock_names[NUM_LEDS];
 extern char *lock_names[NUM_LEDS];
 
 int xkbleds_init();
-gboolean xkbleds_get_state();
+void xkbleds_finish();
+void refresh();
 
 G_END_DECLS
 


### PR DESCRIPTION
Hi!

I've noticed a very small delay in the update of the indicators, and looking through the code, as it happens, it is updated with a timer of 250ms.

Also, this callback is called 4 times per second, even if nobody is at the keyboard, wasting CPU.

This PR uses XKB messages instead of the timer. Now the update is immediate and the CPU usage is slightly lower. Win-Win!

A notable change is that now it reuses the X11 connection by GDK. I don't know if you were preventing that on purpose (to avoid messing with the rest of the panel?), but connecting and disconnecting to the server on every time-out seemed a bit wasteful. Now, I have to use the GDK display so that `gdk_window_add_filter()` works. The alternative would be to create our own `XDisplay` and pump the messages in a custom thread, less intrusive but not so nice.