### PR TITLE
panel-plugin: add missing x11 linker flags

### DIFF
--- a/panel-plugin/Makefile.am
+++ b/panel-plugin/Makefile.am
@@ -22,6 +22,7 @@ libkbdleds_la_SOURCES = \
 	kbdleds-dialogs.h
 
 libkbdleds_la_CFLAGS = \
+	$(LIBX11_CFLAGS) \
 	$(LIBXFCE4UTIL_CFLAGS) \
 	$(LIBXFCE4UI_CFLAGS) \
 	$(LIBXFCE4PANEL_CFLAGS) \
@@ -35,6 +36,7 @@ libkbdleds_la_LDFLAGS = \
        $(PLATFORM_LDFLAGS)
 
 libkbdleds_la_LIBADD = \
+	$(LIBX11_LIBS) \
 	$(LIBXFCE4UTIL_LIBS) \
 	$(LIBXFCE4UI_LIBS) \
 	$(LIBXFCE4PANEL_LIBS)


### PR DESCRIPTION
The configure.ac.in has `XDT_CHECK_LIBX11_REQUIRE`, but fails to use the provided `$(LIBX11_CFLAGS)` and `$(LIBX11_LIBS)` variables in the build.

While the build has `-no-undefined` GNU libtool will silently ignore that flag, but when built with slibtool instead it correctly passes `-Wl,--no-undefined` to the linker revealing this issue.

Gentoo issue: https://bugs.gentoo.org/913681